### PR TITLE
Use multistage and build parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,30 @@
-FROM openjdk:jre-alpine
+# Defaults if not specified in --build-arg
+ARG sbt_version=1.1.4
+ARG sbt_home=/usr/local/sbt
 
-ENV sbt_version 1.1.4
-ENV sbt_home /usr/local/sbt
-ENV PATH ${PATH}:${sbt_home}/bin
+FROM openjdk:jre-alpine as unzip
+ARG sbt_version
+ARG sbt_home
 
-# Install sbt
-RUN apk add --no-cache --update bash wget && \
-    mkdir -p "$sbt_home" && \
-    wget -qO - --no-check-certificate "https://github.com/sbt/sbt/releases/download/v$sbt_version/sbt-$sbt_version.tgz" | tar xz -C $sbt_home --strip-components=1 && \
-    apk del wget && \
-    sbt sbtVersion
-WORKDIR /app
+# Cleverly placed here for caching reasons
+RUN apk add --no-cache --update bash
+
+# Download and extract from archive
+RUN apk add --no-cache --update wget
+RUN mkdir -pv "$sbt_home"
+RUN wget -qO - "https://github.com/sbt/sbt/releases/download/v$sbt_version/sbt-$sbt_version.tgz" >/tmp/sbt.tgz
+RUN tar xzf /tmp/sbt.tgz -C "$sbt_home" --strip-components=1
+
+
+# Make a clean image (i.e., without extra packages)
+FROM openjdk:jre-alpine as release
+ARG sbt_home
+
+# sbt requires bash at run-time.
+RUN apk add --no-cache --update bash  
+
+COPY --from=unzip $sbt_home $sbt_home
+RUN ln -sv "$sbt_home"/bin/sbt /usr/bin/
+
+# This triggers a bunch of useful downloads.
+RUN sbt sbtVersion


### PR DESCRIPTION
Hi!  I needed to make one of these for sbt 1.2.x, so I thought I would start with yours.  This one lets you choose the sbt version more easily at build-time and has other performance enhancements.  (The sbt version in this commit is still 1.1.4.) If you have any questions, please do let me know.

* Allow Docker to take advantage of layer caching via multiple RUN statements (instead of `&& \` at end-of-line)
* To keep image size down, I used multistage instead of deleting build-time packages.
* sbt seems to require bash at run-time.